### PR TITLE
Validation phase (ResNets training)

### DIFF
--- a/training.py
+++ b/training.py
@@ -18,12 +18,18 @@ import re
 import os
 from torch.utils.tensorboard import SummaryWriter
 import random
+from torch import nn
 
 # Setup checkpointing
 COLAB_PATH = os.getenv('COLAB_PATH')
 CHECKPOINT_PATH = "checkpoints" if COLAB_PATH is None else COLAB_PATH  # "checkpoints/checkpoint_1.tar"
-if not os.path.isdir(CHECKPOINT_PATH):
-    os.makedirs(CHECKPOINT_PATH)
+MODE_ACTION = "action"
+MODE_PRIVACY = "privacy"
+CHECKPOINT_PATH_ACTION = os.path.join(CHECKPOINT_PATH, MODE_ACTION)
+CHECKPOINT_PATH_PRIVACY = os.path.join(CHECKPOINT_PATH, MODE_PRIVACY)
+for checkpoint_path in [CHECKPOINT_PATH, CHECKPOINT_PATH_ACTION, CHECKPOINT_PATH_PRIVACY]:
+    if not os.path.isdir(checkpoint_path):
+        os.makedirs(checkpoint_path)
 
 # Set accelerator
 device = torch.accelerator.current_accelerator() if torch.accelerator.is_available() else "cpu"
@@ -34,21 +40,21 @@ np.random.seed(42)
 random.seed(42)
 
 
-def get_sorted_checkpoints():
+def get_sorted_checkpoints(checkpoint_path: str):
     checkpoints = []
     try:
-        files = os.listdir(CHECKPOINT_PATH)
+        files = os.listdir(checkpoint_path)
     except FileNotFoundError:
         return checkpoints
     for file in files:
         match = re.search(r'checkpoint_(\d+)\.tar$', file)
         if match:
-            checkpoints.append((os.path.join(CHECKPOINT_PATH, file), int(match.group(1))))
+            checkpoints.append((os.path.join(checkpoint_path, file), int(match.group(1))))
     checkpoints.sort(key=lambda x: x[1])
     return checkpoints
 
-def delete_old_checkpoints():
-    checkpoints = get_sorted_checkpoints()
+def delete_old_checkpoints(checkpoint_path: str):
+    checkpoints = get_sorted_checkpoints(checkpoint_path)
     if len(checkpoints) > 2:
         for file, _ in checkpoints[:-2]:
             os.remove(file)
@@ -78,7 +84,7 @@ def compute_accuracy(input, target_action, target_privacy, random_frame: int | N
 def train_once(train_dataloader: DataLoader, E: BDQEncoder, T: ActionRecognitionModel, P: PrivacyAttributePredictor, 
                action_loss: ActionLoss, privacy_loss: PrivacyLoss, optimizer_ET: Optimizer, optimizer_P: Optimizer):
     """
-    Function to perform one training epoch of adverserial training from https://arxiv.org/abs/2208.02459
+    Function to perform one training epoch of adversarial training from https://arxiv.org/abs/2208.02459
     Args:
         train_dataloader: DataLoader for the training split of the KTH dataset
         E: the BDQ encoder
@@ -142,9 +148,9 @@ def train_once(train_dataloader: DataLoader, E: BDQEncoder, T: ActionRecognition
     return total_loss_action, total_loss_privacy, total_acc_action, total_acc_privacy
 
 def validate_once(val_dataloader: DataLoader, E: BDQEncoder, T: ActionRecognitionModel, P: PrivacyAttributePredictor, 
-                  action_loss: ActionLoss, privacy_loss: PrivacyLoss):
+                  loss):
     """
-    Function to perform one validation epoch of adverserial training from https://arxiv.org/abs/2208.02459
+    Function to perform one validation epoch of adversarial training from https://arxiv.org/abs/2208.02459
     Args:
         val_dataloader: DataLoader for the validation split of the KTH dataset
         E: the BDQ encoder
@@ -178,13 +184,11 @@ def validate_once(val_dataloader: DataLoader, E: BDQEncoder, T: ActionRecognitio
                 privacy_preds.append(P.forward(input_encoded[:, frame, :, :, :]))
 
             # Compute statistics
-            loss_action = 0
+            loss_action = loss.forward(action_pred, target_action)
             loss_privacy = 0
             for frame in range(frames):
                 privacy_pred = privacy_preds[frame]
-                loss_action += action_loss.forward(action_pred, privacy_pred, target_action)
-                loss_privacy += privacy_loss.forward(privacy_pred, target_privacy)
-            loss_action /= frames
+                loss_privacy += loss.forward(privacy_pred, target_privacy)
             loss_privacy /= frames
 
             acc_action, acc_privacy = compute_accuracy(input, target_action, target_privacy)
@@ -200,11 +204,11 @@ def validate_once(val_dataloader: DataLoader, E: BDQEncoder, T: ActionRecognitio
 
         return total_loss_action, total_loss_privacy, total_acc_action, total_acc_privacy
 
-def adverserial_training(train_dataloader: DataLoader, val_dataloader: DataLoader, E: BDQEncoder, T: ActionRecognitionModel, 
+def adversarial_training(train_dataloader: DataLoader, val_dataloader: DataLoader, E: BDQEncoder, T: ActionRecognitionModel,
                          P: PrivacyAttributePredictor, optimizer_ET: Optimizer, optimizer_P: Optimizer, scheduler_ET: LRScheduler, 
-                         scheduler_P: LRScheduler, action_loss: ActionLoss, privacy_loss: PrivacyLoss, writer: SummaryWriter, last_epoch=0, num_epochs=50):
+                         scheduler_P: LRScheduler, action_loss: ActionLoss, privacy_loss: PrivacyLoss, writer: SummaryWriter, cross_entropy, last_epoch=0, num_epochs=50):
     """
-    Function encapsulating the whole adverserial training process from https://arxiv.org/abs/2208.02459.
+    Function encapsulating the whole adversarial training process from https://arxiv.org/abs/2208.02459.
     If last_epoch >= num_epochs then only runs validation once.
     Args:
         train_dataloader: DataLoader for the training split of the KTH dataset
@@ -231,22 +235,22 @@ def adverserial_training(train_dataloader: DataLoader, val_dataloader: DataLoade
             'scheduler_ET_state_dict': scheduler_ET.state_dict(),
             'scheduler_P_state_dict': scheduler_P.state_dict(),
         }, os.path.join(CHECKPOINT_PATH, f"checkpoint_{epoch}.tar"))
-        delete_old_checkpoints()
+        delete_old_checkpoints(CHECKPOINT_PATH)
 
     if last_epoch >= num_epochs:
         val_loss_action, val_loss_privacy, val_acc_action, val_acc_privacy = validate_once(val_dataloader=val_dataloader, E=E, T=T, P=P, 
-                                                                                            action_loss=action_loss, privacy_loss=privacy_loss)
+                                                                                            loss=cross_entropy)
         print(f"Action accuracy: {val_acc_action:.4f}, Privacy accuracy: {val_acc_privacy:.4f}")
         print(f"Action Loss: {val_loss_action:.4f}, Privacy Loss: {val_loss_privacy:.4f}")
 
-    with tqdm(range(last_epoch, num_epochs), total=num_epochs, initial=last_epoch, desc="Adverserial training", unit="epoch", position=0, leave=True) as progress_loader:
+    with tqdm(range(last_epoch, num_epochs), total=num_epochs, initial=last_epoch, desc="Adversarial training", unit="epoch", position=0, leave=True) as progress_loader:
         for epoch in progress_loader:
             train_loss_action, train_loss_privacy, train_acc_action, train_acc_privacy = train_once(train_dataloader=train_dataloader, E=E, T=T, P=P, 
                                                                                                     action_loss=action_loss, privacy_loss=privacy_loss, 
                                                                                                     optimizer_ET=optimizer_ET, optimizer_P=optimizer_P)
             
             val_loss_action, val_loss_privacy, val_acc_action, val_acc_privacy = validate_once(val_dataloader=val_dataloader, E=E, T=T, P=P, 
-                                                                                            action_loss=action_loss, privacy_loss=privacy_loss)
+                                                                                            loss=cross_entropy)
 
             # Update learning rates
             scheduler_ET.step()
@@ -266,6 +270,119 @@ def adverserial_training(train_dataloader: DataLoader, val_dataloader: DataLoade
                                          action_accuracy=val_acc_action.numpy(), privacy_accuracy= val_acc_privacy.numpy())
             progress_loader.refresh()
 
+def train_once_resnet(train_dataloader: DataLoader, E: BDQEncoder, T: ActionRecognitionModel, P: PrivacyAttributePredictor,
+                      loss, optimizer: Optimizer, mode: str):
+    """
+    Function to perform one training epoch of validation training from https://arxiv.org/abs/2208.02459
+    Args:
+        train_dataloader: DataLoader for the training split of the KTH dataset
+        E: the BDQ encoder
+        T: 3d resnet50 for predicting target action attributes
+        P: 2d resnet50 for predicting target privacy attributes
+        loss: criterion for optimizing attribute prediction
+        optimizer: SGD optimizer for the attribute predictor
+    """
+    # Set all components to training mode
+    E.train()
+    T.train()
+    P.train()
+
+    total_loss_action = torch.tensor(0.)
+    total_loss_privacy = torch.tensor(0.)
+    total_acc_action = torch.tensor(0.)
+    total_acc_privacy = torch.tensor(0.)
+
+    for input, target_action, target_privacy in tqdm(train_dataloader, total=len(train_dataloader), desc="Training epoch...", unit="batch", position=1, leave=False):
+        input = input.to(device)
+        target_action = target_action.to(device)
+        target_privacy = target_privacy.to(device)
+
+        # Reset gradients
+        optimizer.zero_grad()
+
+        # train T or P
+        with torch.no_grad():
+            frozen_input_encoded = E.forward(input)
+        action_pred = T.forward(frozen_input_encoded)
+        # Pick random frame for 2D privacy predictor
+        random_frame = random.randint(0, frozen_input_encoded.size(1) - 1)
+        privacy_pred = P.forward(frozen_input_encoded[:, random_frame, :, :, :])
+        loss_action = loss.forward(action_pred, target_action)
+        loss_privacy = loss.forward(privacy_pred, target_privacy)
+        if mode == 'action':
+            loss = loss_action
+        elif mode == 'privacy':
+            loss = loss_privacy
+        loss.backward()
+        optimizer.step()
+
+        # record losses
+        # Compute statistics
+        acc_action, acc_privacy = compute_accuracy(input, target_action, target_privacy, random_frame)
+
+        total_loss_action += loss_action.item()
+        total_loss_privacy += loss_privacy.item()
+
+        total_acc_action += acc_action.item()
+        total_acc_privacy += acc_privacy.item()
+
+    # Average out accuracies
+    total_acc_action /= len(train_dataloader.dataset)
+    total_acc_privacy /= len(train_dataloader.dataset)
+
+    return total_loss_action, total_loss_privacy, total_acc_action, total_acc_privacy
+
+def resnet_training(train_dataloader: DataLoader, val_dataloader: DataLoader, E: BDQEncoder, T: ActionRecognitionModel,
+                    P: PrivacyAttributePredictor, optimizer: Optimizer, scheduler: LRScheduler,
+                    loss, writer: SummaryWriter, mode: str, last_epoch=0, num_epochs=50):
+    """
+    Function encapsulating the whole validation training process from https://arxiv.org/abs/2208.02459.
+    Args:
+        train_dataloader: DataLoader for the training split of the KTH dataset
+        val_dataloader: DataLoader for the validation split of the KTH dataset
+        E: the BDQ encoder
+        T: 3d resnet50 for predicting target action attributes
+        P: 2d resnet50 for predicting target privacy attributes
+        optimizer: SGD optimizer for the attribute predictor
+        scheduler: learning rate scheduler for updating learning rate each epoch for optimizer
+        loss: criterion for optimizing attribute prediction
+        last_epoch (optional, int): checkpoint of last saved epoch
+        num_epochs (optional, int): number of epochs to train for (default=50)
+    """
+    def save_checkpoint(epoch: int):
+        torch.save({
+            'T_state_dict': T.state_dict(),
+            'P_state_dict': P.state_dict(),
+            'optim_state_dict': optimizer.state_dict(),
+            'scheduler_state_dict': scheduler.state_dict(),
+        }, os.path.join(CHECKPOINT_PATH, mode, f"checkpoint_{epoch}.tar"))
+        delete_old_checkpoints(os.path.join(CHECKPOINT_PATH, mode))
+
+    with tqdm(range(last_epoch, num_epochs), total=num_epochs, initial=last_epoch, desc=f"{mode} ResNet training", unit="epoch", position=0, leave=True) as progress_loader:
+        for epoch in progress_loader:
+            train_loss_action, train_loss_privacy, train_acc_action, train_acc_privacy = train_once_resnet(train_dataloader=train_dataloader, E=E, T=T, P=P,
+                                                                                                           loss=loss, optimizer=optimizer, mode=mode)
+
+            val_loss_action, val_loss_privacy, val_acc_action, val_acc_privacy = validate_once(val_dataloader=val_dataloader, E=E, T=T, P=P,
+                                                                                            loss=loss)
+
+            # Update learning rates
+            scheduler.step()
+            save_checkpoint(epoch + 1)
+            writer.add_scalars(f"Loss_{mode}", {'train_loss_action': train_loss_action,
+                                        'train_loss_privacy': train_loss_privacy,
+                                        'val_loss_action': val_loss_action,
+                                        'val_loss_privacy': val_loss_privacy}, epoch)
+            writer.add_scalars(f'Accuracy_{mode}', {'train_acc_action': train_acc_action,
+                                        'train_acc_privacy': train_acc_privacy,
+                                        'val_acc_action': val_acc_action,
+                                        'val_acc_privacy': val_acc_privacy}, epoch)
+
+            # Display statistics
+            progress_loader.set_postfix(action_loss=val_loss_action.numpy(), privacy_loss=val_loss_privacy.numpy(),
+                                         action_accuracy=val_acc_action.numpy(), privacy_accuracy=val_acc_privacy.numpy())
+            progress_loader.refresh()
+
 def load_train_checkpoint(E: BDQEncoder, T: ActionRecognitionModel, P: PrivacyAttributePredictor,
                optim_ET: Optimizer, optim_P: Optimizer, scheduler_ET: LRScheduler, scheduler_P: LRScheduler, PATH: str | None):
     if PATH is None:
@@ -281,6 +398,18 @@ def load_train_checkpoint(E: BDQEncoder, T: ActionRecognitionModel, P: PrivacyAt
     optim_P.load_state_dict(checkpoint['optim_P_state_dict'])
     scheduler_ET.load_state_dict(checkpoint['scheduler_ET_state_dict'])
     scheduler_P.load_state_dict(checkpoint['scheduler_P_state_dict'])
+
+def load_resnet_train_checkpoint(T: ActionRecognitionModel, P: PrivacyAttributePredictor,
+               optim: Optimizer, scheduler: LRScheduler, PATH: str | None):
+    if PATH is None:
+        return
+    checkpoint = torch.load(PATH, weights_only=True, map_location=torch.device(device))
+    T.load_state_dict(checkpoint['T_state_dict'])
+    T.to(device)
+    P.load_state_dict(checkpoint['P_state_dict'])
+    P.to(device)
+    optim.load_state_dict(checkpoint['optim_state_dict'])
+    scheduler.load_state_dict(checkpoint['scheduler_state_dict'])
 
 if __name__ == "__main__":
     # Specify location of KTH dataset and labels file
@@ -344,7 +473,7 @@ if __name__ == "__main__":
     optim_P = SGD(params=P.parameters(), lr=lr)
     scheduler_ET = CosineAnnealingLR(optimizer=optim_ET, T_max=num_epochs)
     scheduler_P = CosineAnnealingLR(optimizer=optim_P, T_max=num_epochs)
-    checkpoints = get_sorted_checkpoints()
+    checkpoints = get_sorted_checkpoints(CHECKPOINT_PATH)
     last_checkpoint_path = None
     last_epoch = 0
     if len(checkpoints) > 0:
@@ -352,10 +481,46 @@ if __name__ == "__main__":
     load_train_checkpoint(E, T, P, optim_ET, optim_P, scheduler_ET, scheduler_P, last_checkpoint_path)
     criterion_action = ActionLoss(alpha=1)
     criterion_privacy = PrivacyLoss()
+    cross_entropy = nn.CrossEntropyLoss().to(device)
 
-    adverserial_training(train_dataloader=train_dataloader, val_dataloader=val_dataloader, E=E, T=T, P=P, 
+    adversarial_training(train_dataloader=train_dataloader, val_dataloader=val_dataloader, E=E, T=T, P=P,
                          optimizer_ET=optim_ET, optimizer_P=optim_P, scheduler_ET=scheduler_ET, 
                          scheduler_P=scheduler_P, action_loss=criterion_action, privacy_loss=criterion_privacy,
-                         writer=writer, last_epoch=last_epoch, num_epochs=num_epochs)
+                         writer=writer, cross_entropy=cross_entropy, last_epoch=last_epoch, num_epochs=num_epochs)
+
+    # Re-initialize the action attribute predictor (T),
+    # and the privacy attribute predictor (P)
+    T = ActionRecognitionModel(fine_tune=True, num_classes=6).to(device)
+    P = PrivacyAttributePredictor(num_privacy_classes=25).to(device)
+
+    # Initialize optimizer and scheduler
+    optim = SGD(params=T.parameters(), lr=lr)
+    scheduler = CosineAnnealingLR(optimizer=optim, T_max=num_epochs)
+    checkpoints = get_sorted_checkpoints(CHECKPOINT_PATH_ACTION)
+    last_checkpoint_path = None
+    last_epoch = 0
+    if len(checkpoints) > 0:
+        last_checkpoint_path, last_epoch = checkpoints[-1]
+    load_resnet_train_checkpoint(T=T, P=P, optim=optim, scheduler=scheduler, PATH=last_checkpoint_path)
+
+    resnet_training(train_dataloader=train_dataloader, val_dataloader=val_dataloader, E=E, T=T, P=P,
+                    optimizer=optim, scheduler=scheduler,
+                    loss=cross_entropy,
+                    writer=writer, mode=MODE_ACTION, last_epoch=last_epoch, num_epochs=num_epochs)
+
+    # Initialize optimizer and scheduler
+    optim = SGD(params=P.parameters(), lr=lr)
+    scheduler = CosineAnnealingLR(optimizer=optim, T_max=num_epochs)
+    checkpoints = get_sorted_checkpoints(CHECKPOINT_PATH_PRIVACY)
+    last_checkpoint_path = None
+    last_epoch = 0
+    if len(checkpoints) > 0:
+        last_checkpoint_path, last_epoch = checkpoints[-1]
+    load_resnet_train_checkpoint(T=T, P=P, optim=optim, scheduler=scheduler, PATH=last_checkpoint_path)
+
+    resnet_training(train_dataloader=train_dataloader, val_dataloader=val_dataloader, E=E, T=T, P=P,
+                    optimizer=optim, scheduler=scheduler,
+                    loss=cross_entropy,
+                    writer=writer, mode=MODE_PRIVACY, last_epoch=last_epoch, num_epochs=num_epochs)
     writer.flush()
     writer.close()


### PR DESCRIPTION
I think this "validation" part aligns more with paper's implementation see train1 and validate1 from https://github.com/suakaw/BDQ_PrivacyAR/blob/main/action-recognition-pytorch-entropy/utils/utils.py#L318 . And this https://github.com/suakaw/BDQ_PrivacyAR/blob/main/action-recognition-pytorch-entropy/train.py#L427 (TARGET MODEL TRAINING and BUDGET MODEL TRAINING). Although authors claim in the paper that they average softmax outputs across frames, apparently they adopt different method in the implementation (take random frame), only sign of possible mean usage is https://github.com/suakaw/BDQ_PrivacyAR/blob/main/action-recognition-pytorch-entropy/models/twod_models/resnet.py#L220 , but I wasn't able to identify if this ResNet is used anywhere, all models pointed to different ResNets implementations https://github.com/suakaw/BDQ_PrivacyAR/blob/main/action-recognition-pytorch-entropy/models/threed_models/i3d.py#L19 .
It would be nice to somehow refactor the train_once_... and ..._training functions, but I don't know if that would be more readable.